### PR TITLE
Bump apexpy in env to 2.0.1

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - xarray=2022.10
   - pip:
     - aacgmv2==2.6.2
-    - apexpy==1.1.0
+    - apexpy==2.0.1
     - cdflib==0.4.7
     - madrigalWeb==3.2.2
     - ppigrf==1.0.0


### PR DESCRIPTION
This should(?) fix the install using the conda env on macOS