### PR TITLE
Fix reading errors as an array

### DIFF
--- a/lompe/model/data.py
+++ b/lompe/model/data.py
@@ -141,7 +141,7 @@ class Data(object):
 
         assert scale is None,"'scale' keyword is deprecated! Please use 'iweight' (\"importance weight\") instead"
 
-        if error == 0:
+        if error.size == 1 and error[0] == 0:
             error = errors[datatype]
             warnings.warn(f"'error' keyword not set for datatype '{datatype}'! Using error={error}", UserWarning)
         

--- a/lompe/model/data.py
+++ b/lompe/model/data.py
@@ -141,9 +141,10 @@ class Data(object):
 
         assert scale is None,"'scale' keyword is deprecated! Please use 'iweight' (\"importance weight\") instead"
 
-        if error.size == 1 and error[0] == 0:
-            error = errors[datatype]
-            warnings.warn(f"'error' keyword not set for datatype '{datatype}'! Using error={error}", UserWarning)
+        if np.array(error).size == 1:
+            if error == 0:
+                 error = errors[datatype]
+                 warnings.warn(f"'error' keyword not set for datatype '{datatype}'! Using error={error}", UserWarning)
         
         if iweight is None:
             iweight = iweights[datatype]


### PR DESCRIPTION
As it stands, passing an array to the `error` keyword in the `Data` class doesn't work, as checks `if error == 0:`. This fails if `error` is an array of the same length of `values`. 

A simple fix for this is to check if error has a size of 1, which is also equal to zero. The size check is actually done later at L187 of data.py, but the code will fail before getting to that point.