### PR TITLE
Added back to check that there is data when building inversion matrices

### DIFF
--- a/lompe/data_tools/dataloader.py
+++ b/lompe/data_tools/dataloader.py
@@ -495,7 +495,7 @@ def read_sdarn(event, basepath='./', tempfile_path='./', hemi='north'):
                 temp2.loc[:,'stime'] = stime
                 temp2.loc[:,'etime'] = etime
                 temp2.loc[:,'duration'] = duration
-                temp = temp.append(temp2)
+                temp = pd.concat([temp,temp2],ignore_index=True)
         
         temp.loc[:,'mlat'] = tt['vector.mlat']              # in degrees AACGM
         temp.loc[:,'mlon'] = tt['vector.mlon']              # in degrees AACGM
@@ -506,7 +506,7 @@ def read_sdarn(event, basepath='./', tempfile_path='./', hemi='north'):
         temp.loc[:,'wdt'] = tt['vector.wdt.median']         # spectral width in m/s
         temp.loc[:,'time'] = stime + duration/2
         
-        ddd = ddd.append(temp)
+        ddd = pd.concat([ddd, temp], ignore_index=True)
     
     ddd.index = ddd.time
 


### PR DESCRIPTION
For some reason 'if ds.coords['lat'].size > 1: #If there is data inside biggrid ' was removed on line 289.
If it turns out that the dataset added has no data inside the biggrid region, the subsequent building of GTG and GTd will fail. Not sure why this was removed. I can not see anything elsewhere in the code that should prevent it from chrashing, which was why i came across this.

Changed also from the deprecated pd.append to pd.concat in dataloader.py. This was pointed out by @billetd  in #31 . This fix should close that issue.