### PR TITLE
Latitude dependent regularization

### DIFF
--- a/lompe/model/model.py
+++ b/lompe/model/model.py
@@ -1013,7 +1013,7 @@ class Emodel(object):
 
         shape = np.broadcast(lon, lat).shape
 
-        S_cf = -self._B_cf_matrix(return_poles = True)
+        S_cf =  self._B_cf_matrix(return_poles = True)
         S_df =  self._B_df_matrix(return_poles = True)
 
         Be_cf, Bn_cf = get_SECS_J_G_matrices(lat, lon, self.lat_J, self.lon_J,

--- a/lompe/model/model.py
+++ b/lompe/model/model.py
@@ -141,11 +141,11 @@ class Emodel(object):
         # matrix L that calculates derivative in magnetic eastward direction on grid_E:
         De2, Dn2 = self.grid_E.get_Le_Ln()
         if self.dipole: # L matrix gives gradient in eastward direction
-            self.L = De2 * lat_w(self.hemisphere * grid_E.lat.flatten()).reshape((-1, 1))
+            self.L = De2 * lat_w(self.hemisphere * self.grid_E.lat.flatten()).reshape((-1, 1))
             self.LTL = self.L.T.dot(self.L)
         else: # L matrix gives gradient in QD eastward direction
             apx = apexpy.Apex(epoch, refh = refh)
-            mlat, mlon = apx.geo2apex(grid_E.lat.flatten(), grid_E.lon.flatten(), refh)
+            mlat, mlon = apx.geo2apex(self.grid_E.lat.flatten(), self.grid_E.lon.flatten(), refh)
             f1, f2 = apx.basevectors_qd(self.grid_E.lat.flatten(), self.grid_E.lon.flatten(), refh)
             f1 = f1/np.linalg.norm(f1, axis = 0)
             self.L = De2 * f1[0].reshape((-1, 1)) + Dn2 * f1[1].reshape((-1, 1))


### PR DESCRIPTION
This adds an option to cancel the east-west regularization close to the pole. The idea is that ionospheric electrodynamics tends to align in the magnetic east-west direction in the auroral zone, but not in the polar cap. This addition can prevent strange-looking east-west structures near the pole. 